### PR TITLE
Add EndOfCheckPhase processor

### DIFF
--- a/Kurzweil/KurzweilWeb.download.recipe
+++ b/Kurzweil/KurzweilWeb.download.recipe
@@ -37,6 +37,10 @@
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/LociTools/LociTools.download.recipe
+++ b/LociTools/LociTools.download.recipe
@@ -37,6 +37,10 @@
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/Tracker/Tracker.download.recipe
+++ b/Tracker/Tracker.download.recipe
@@ -39,6 +39,10 @@
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
The EndOfCheckPhase processor allows administrators to use `autopkg run --check`, which is typically used to check for newly available software versions but not process any subsequent steps. It's typical to include the EndOfCheckPhase processor in most .download recipes.