### PR TITLE
Fix Tracker download recipe

### DIFF
--- a/Tracker/Tracker.download.recipe
+++ b/Tracker/Tracker.download.recipe
@@ -32,9 +32,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%-%version%.zip</string>
+				<string>%NAME%-%version%.dmg</string>
 				<key>url</key>
-				<string>http://physlets.org/tracker/installers/download.php?file=Tracker-%version%-osx-installer.zip</string>
+				<string>http://physlets.org/tracker/installers/download.php?file=Tracker-%version%-osx-installer.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/Tracker/Tracker.download.recipe
+++ b/Tracker/Tracker.download.recipe
@@ -19,7 +19,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>file=Tracker-([0-9\.]+)-osx-installer.zip</string>
+				<string>file=Tracker-([0-9\.]+)-osx-installer.dmg</string>
 				<key>result_output_var_name</key>
 				<string>version</string>
 				<key>url</key>


### PR DESCRIPTION
Addresses https://github.com/autopkg/vmiller-recipes/issues/10

File is now a DMG rather than a .zip file.