### PR TITLE
Include -k curl opt in URLTextSearcher

### DIFF
--- a/NetLogo/NetLogo.download.recipe
+++ b/NetLogo/NetLogo.download.recipe
@@ -18,6 +18,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>curl_opts</key>
+				<array>
+					<string>-k</string>
+				</array>
 				<key>re_pattern</key>
 				<string>(option selected value="NetLogo )([0-9-A-Z\.]+)</string>
 				<key>result_output_var_name</key>


### PR DESCRIPTION
Please add a curl opt flag to the NetLogo recipe. Currently URLTextSearcher curl is failing with error 60 due to their SSL configuration. This will disable SSL verification only for the search part, not the download portion. Thanks. 