### PR TITLE
NetLogo Logging no longer included

### DIFF
--- a/NetLogo/NetLogo.download.recipe
+++ b/NetLogo/NetLogo.download.recipe
@@ -84,17 +84,6 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/NetLogo %CURRENT_VERSION%/NetLogo Logging %CURRENT_VERSION%.app</string>
-				<key>requirement</key>
-				<string>identifier "org.nlogo.NetLogo" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = E74ZKF37E6</string>
-			</dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_path</key>
 				<string>%pathname%/NetLogo %CURRENT_VERSION%/NetLogo 3D %CURRENT_VERSION%.app</string>
 				<key>requirement</key>
 				<string>identifier "org.nlogo.NetLogo3D" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = E74ZKF37E6</string>

--- a/NetLogo/NetLogo.munki.recipe
+++ b/NetLogo/NetLogo.munki.recipe
@@ -62,7 +62,6 @@
 					<string>/Applications/NetLogo %CURRENT_VERSION%/Behaviorsearch %CURRENT_VERSION%.app</string>
 					<string>/Applications/NetLogo %CURRENT_VERSION%/HubNet Client %CURRENT_VERSION%.app</string>
 					<string>/Applications/NetLogo %CURRENT_VERSION%/NetLogo %CURRENT_VERSION%.app</string>
-					<string>/Applications/NetLogo %CURRENT_VERSION%/NetLogo Logging %CURRENT_VERSION%.app</string>
 					<string>/Applications/NetLogo %CURRENT_VERSION%/NetLogo 3D %CURRENT_VERSION%.app</string>
 				</array>
 			</dict>


### PR DESCRIPTION
The NetLog Logging app no longer exists on the downloaded DMG.  The CodeSignatureVerifier and the Munki installs array were changed to reflect this.