### PR TITLE
Update NetLogo.munki.recipe

### DIFF
--- a/NetLogo/NetLogo.munki.recipe
+++ b/NetLogo/NetLogo.munki.recipe
@@ -3,11 +3,15 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of NetLogo and imports it into Munki.</string>
+	<string>Downloads the latest version of NetLogo and imports it into Munki.
+
+Set the DERIVE_MIN_OS variable to a non-empty string to set the minimum_os_version via MunkiInstallsItemsCreator. This requires a minimum AutoPkg version of 2.7 please update if you're not already running it.</string>
 	<key>Identifier</key>
 	<string>com.github.vmiller.munki.netlogo</string>
 	<key>Input</key>
 	<dict>
+		<key>DERIVE_MIN_OS</key>
+		<string>YES</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/NetLogo</string>
 		<key>NAME</key>
@@ -35,7 +39,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.9</string>
+	<string>2.7</string>
 	<key>ParentRecipe</key>
 	<string>com.github.vmiller.pkg.netlogo</string>
 	<key>Process</key>
@@ -56,7 +60,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>faux_root</key>
-                <string>%RECIPE_CACHE_DIR%/pkgroot/</string>
+				<string>%RECIPE_CACHE_DIR%/pkgroot/</string>
 				<key>installs_item_paths</key>
 				<array>
 					<string>/Applications/NetLogo %CURRENT_VERSION%/Behaviorsearch %CURRENT_VERSION%.app</string>
@@ -64,6 +68,8 @@
 					<string>/Applications/NetLogo %CURRENT_VERSION%/NetLogo %CURRENT_VERSION%.app</string>
 					<string>/Applications/NetLogo %CURRENT_VERSION%/NetLogo 3D %CURRENT_VERSION%.app</string>
 				</array>
+				<key>derive_minimum_os_version</key>
+				<string>%DERIVE_MIN_OS%</string>
 			</dict>
 			<key>Processor</key>
 			<string>MunkiInstallsItemsCreator</string>


### PR DESCRIPTION
Hi, @vmiller 

The NetLogo Munki recipe currently doesn't set the `minimum_os_version` from the App's info.plist, and as such a default value of 10.5.0 is being set.

This PR adds in support for the new `derive_minimum_os_version` key in the `MunkiInstallsItemsCreator` processor. With this set the min_os_version becomes 10.8.3

This change requires AutoPkg version 2.7 or higher, if compatibility with older versions of AutoPkg is needed, the same result could be achieved with something like below.

```
        <dict>
            <key>Arguments</key>
            <dict>
                <key>info_path</key>
                <string>%RECIPE_CACHE_DIR%/Applications/APP_NAME.app</string>
                <key>plist_keys</key>
                <dict>
                    <key>LSMinimumSystemVersion</key>
                    <string>min_os_ver</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>PlistReader</string>
        </dict>
        <dict>
             <key>Arguments</key>
             <dict>
                <key>additional_pkginfo</key>
                <dict>
                    <key>minimum_os_version</key>
                    <string>%min_os_ver%</string>
                </dict>
            </dict>
            <key>Processor</key>
            <string>MunkiPkginfoMerger</string>
        </dict>
```

Output from a successful verbose run:

```
autopkg run -v /Users/paul/Documents/GitHub/AutoPkg\ Repos/vmiller-recipes/NetLogo/NetLogo.munki.recipe 
Processing /Users/paul/Documents/GitHub/AutoPkg Repos/vmiller-recipes/NetLogo/NetLogo.munki.recipe...
WARNING: /Users/paul/Documents/GitHub/AutoPkg Repos/vmiller-recipes/NetLogo/NetLogo.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
URLTextSearcher: Found matching text (CURRENT_VERSION): 6.3.0
URLDownloader
URLDownloader: Storing new Last-Modified header: Thu, 29 Sep 2022 19:15:42 GMT
URLDownloader: Storing new ETag header: "9c4163-14dcf557-5e9d5b412f380"
URLDownloader: Downloaded /Users/paul/Library/AutoPkg/Cache/com.github.vmiller.munki.netlogo/downloads/NetLogo 6.3.0.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.vmiller.munki.netlogo/downloads/NetLogo 6.3.0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.NzLyWu/NetLogo 6.3.0/Behaviorsearch 6.3.0.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.NzLyWu/NetLogo 6.3.0/Behaviorsearch 6.3.0.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.NzLyWu/NetLogo 6.3.0/Behaviorsearch 6.3.0.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.vmiller.munki.netlogo/downloads/NetLogo 6.3.0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.fb47Zm/NetLogo 6.3.0/HubNet Client 6.3.0.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.fb47Zm/NetLogo 6.3.0/HubNet Client 6.3.0.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.fb47Zm/NetLogo 6.3.0/HubNet Client 6.3.0.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.vmiller.munki.netlogo/downloads/NetLogo 6.3.0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.ZGoolk/NetLogo 6.3.0/NetLogo 6.3.0.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.ZGoolk/NetLogo 6.3.0/NetLogo 6.3.0.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.ZGoolk/NetLogo 6.3.0/NetLogo 6.3.0.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.vmiller.munki.netlogo/downloads/NetLogo 6.3.0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.jVFdbZ/NetLogo 6.3.0/NetLogo 3D 6.3.0.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.jVFdbZ/NetLogo 6.3.0/NetLogo 3D 6.3.0.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.jVFdbZ/NetLogo 6.3.0/NetLogo 3D 6.3.0.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
PkgRootCreator
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/com.github.vmiller.munki.netlogo/pkgroot
PkgRootCreator: Created /Users/paul/Library/AutoPkg/Cache/com.github.vmiller.munki.netlogo/pkgroot/Applications
Copier
Copier: Mounted disk image /Users/paul/Library/AutoPkg/Cache/com.github.vmiller.munki.netlogo/downloads/NetLogo 6.3.0.dmg
Copier: Copied /private/tmp/dmg.hMovR9/NetLogo 6.3.0 to /Users/paul/Library/AutoPkg/Cache/com.github.vmiller.munki.netlogo/pkgroot/Applications/NetLogo 6.3.0
PkgCreator
PkgCreator: Connecting
PkgCreator: Sending packaging request
PkgCreator: Disconnecting
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '6.3.0'} into pkginfo
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/NetLogo 6.3.0/Behaviorsearch 6.3.0.app
MunkiInstallsItemsCreator: Derived minimum os version as: 10.8.3
MunkiInstallsItemsCreator: Created installs item for /Applications/NetLogo 6.3.0/HubNet Client 6.3.0.app
MunkiInstallsItemsCreator: Setting minimum os version to: 10.8.3, as greater than prior value of: 10.8.3
MunkiInstallsItemsCreator: Minimum os version: 10.8.3, is lower than prior value of: 10.8.3... skipping...
MunkiInstallsItemsCreator: Created installs item for /Applications/NetLogo 6.3.0/NetLogo 6.3.0.app
MunkiInstallsItemsCreator: Setting minimum os version to: 10.8.3, as greater than prior value of: 10.8.3
MunkiInstallsItemsCreator: Minimum os version: 10.8.3, is lower than prior value of: 10.8.3... skipping...
MunkiInstallsItemsCreator: Created installs item for /Applications/NetLogo 6.3.0/NetLogo 3D 6.3.0.app
MunkiInstallsItemsCreator: Setting minimum os version to: 10.8.3, as greater than prior value of: 10.8.3
MunkiInstallsItemsCreator: Minimum os version: 10.8.3, is lower than prior value of: 10.8.3... skipping...
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'version': '6.3.0', 'installs': [{'CFBundleIdentifier': 'org.nlogo.Behaviorsearch', 'CFBundleName': 'Behaviorsearch', 'CFBundleShortVersionString': '6.3.0', 'CFBundleVersion': '6.3.0', 'minosversion': '10.8.3', 'path': '/Applications/NetLogo 6.3.0/Behaviorsearch 6.3.0.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}, {'CFBundleIdentifier': 'org.nlogo.HubNetClient', 'CFBundleName': 'HubNet Client', 'CFBundleShortVersionString': '6.3.0', 'CFBundleVersion': '6.3.0', 'minosversion': '10.8.3', 'path': '/Applications/NetLogo 6.3.0/HubNet Client 6.3.0.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}, {'CFBundleIdentifier': 'org.nlogo.NetLogo', 'CFBundleName': 'NetLogo', 'CFBundleShortVersionString': '6.3.0', 'CFBundleVersion': '6.3.0', 'minosversion': '10.8.3', 'path': '/Applications/NetLogo 6.3.0/NetLogo 6.3.0.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}, {'CFBundleIdentifier': 'org.nlogo.NetLogo3D', 'CFBundleName': 'NetLogo', 'CFBundleShortVersionString': '6.3.0', 'CFBundleVersion': '6.3.0', 'minosversion': '10.8.3', 'path': '/Applications/NetLogo 6.3.0/NetLogo 3D 6.3.0.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}], 'minimum_os_version': '10.8.3'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/NetLogo/NetLogo-6.3.0__1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/NetLogo/NetLogo-6.3.0__1.pkg
Receipt written to /Users/paul/Library/AutoPkg/Cache/com.github.vmiller.munki.netlogo/receipts/NetLogo.munki-receipt-20230106-110823.plist

The following new items were downloaded:
    Download Path                                                                                   
    -------------                                                                                   
    /Users/paul/Library/AutoPkg/Cache/com.github.vmiller.munki.netlogo/downloads/NetLogo 6.3.0.dmg  

The following packages were built:
    Identifier         Version  Pkg Path                                                                              
    ----------         -------  --------                                                                              
    org.nlogo.NetLogo  6.3.0    /Users/paul/Library/AutoPkg/Cache/com.github.vmiller.munki.netlogo/NetLogo-6.3.0.pkg  

The following new items were imported into Munki:
    Name     Version  Catalogs  Pkginfo Path                         Pkg Repo Path                      Icon Repo Path  
    ----     -------  --------  ------------                         -------------                      --------------  
    NetLogo  6.3.0    testing   apps/NetLogo/NetLogo-6.3.0__1.plist  apps/NetLogo/NetLogo-6.3.0__1.pkg
```