### PR TITLE
remove code siging verification

### DIFF
--- a/PowerShell/PowerShell.download.recipe
+++ b/PowerShell/PowerShell.download.recipe
@@ -49,21 +49,6 @@ ARCH can be one of 'arm64' or 'x64'</string>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
 		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_path</key>
-				<string>%pathname%</string>
-				<key>expected_authority_names</key>
-				<array>
-					<string>Developer ID Installer: Microsoft Corporation (UBF8T346G9)</string>
-					<string>Developer ID Certification Authority</string>
-					<string>Apple Root CA</string>
-				</array>
-			</dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
The PowerShell packages are no longer signed.  This PR removes the code signature verification step