### PR TITLE
Chemdraw Code Signature failing

### DIFF
--- a/ChemDraw/ChemDraw.download.recipe
+++ b/ChemDraw/ChemDraw.download.recipe
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of ChemDraw.</string>
+	<key>Identifier</key>
+	<string>com.github.vmiller.download.ChemDraw</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>ChemDraw</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>2.3</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>appcast_url</key>
+				<string>https://static.chemistry.revvitycloud.com/chemdraw/updates/ChemDrawMacUpdate.xml</string>
+			</dict>
+			<key>Processor</key>
+			<string>SparkleUpdateInfoProvider</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%NAME%-%version%.dmg</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pattern</key>
+				<string>%pathname%/ChemDraw 2*</string>
+			</dict>
+			<key>Processor</key>
+			<string>FileFinder</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/%found_basename%</string>
+				<key>requirement</key>
+				<string>identifier "com.revvity.ChemDraw" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = ZZD6FLC454</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/ChemDraw Collections.app</string>
+				<key>requirement</key>
+				<string>identifier "com.revvity.chemdrawcollections" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = ZZD6FLC454</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/ChemDraw/ChemDraw.download.recipe
+++ b/ChemDraw/ChemDraw.download.recipe
@@ -57,17 +57,6 @@
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
 		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_path</key>
-				<string>%pathname%/ChemDraw Collections.app</string>
-				<key>requirement</key>
-				<string>identifier "com.revvity.chemdrawcollections" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = ZZD6FLC454</string>
-			</dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-		</dict>
 	</array>
 </dict>
 </plist>

--- a/ChemDraw/ChemDraw.munki.recipe
+++ b/ChemDraw/ChemDraw.munki.recipe
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>	
+	<string>Downloads the latest version of ChemDraw and imports it into Munki.  The ChemDraw app is copied into /Application/ChemDraw  This is so that the Activate.ini file can be placed alongside the app for automatic activation.</string>
+	<key>Identifier</key>
+	<string>com.github.vmiller.munki.ChemDraw</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/%NAME%</string>
+		<key>NAME</key>
+		<string>ChemDraw</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>category</key>
+			<string>Chemistry</string>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>description</key>
+			<string>Since 1985 ChemDraw® solutions have provided powerful capabilities and integrations to help you quickly turn ideas and drawings into publications you can be proud of.</string>
+			<key>developer</key>
+			<string>Revvity Signals Software, Inc.</string>
+			<key>display_name</key>
+			<string>ChemDraw</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>preinstall_script</key>
+			<string>#!/bin/sh
+
+			if [ -d "/Applications/ChemDraw/ChemDraw*" ]
+			then
+				/bin/rm -rf "/Applications/ChemDraw/ChemDraw*"
+			fi</string>
+			<key>unattended_install</key>
+			<true/>
+			<key>unattended_uninstall</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>2.3</string>
+	<key>ParentRecipe</key>
+	<string>com.github.vmiller.download.ChemDraw</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+				<key>additional_makepkginfo_options</key>
+				<array>
+					<string>--destinationpath</string>
+					<string>/Applications/ChemDraw</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Version 25 of ChemDraw no longer includes ChemDraw Collections on the disk image.  This commit removes the code signature verification of ChemDraw Collections.