### PR TITLE
remove verification of ChemDraw Collections

### DIFF
--- a/ChemDraw/ChemDraw.download.recipe
+++ b/ChemDraw/ChemDraw.download.recipe
@@ -57,17 +57,6 @@
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
 		</dict>
-		<dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_path</key>
-				<string>%pathname%/ChemDraw Collections.app</string>
-				<key>requirement</key>
-				<string>identifier "com.revvity.chemdrawcollections" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = ZZD6FLC454</string>
-			</dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
ChemDraw Collections.app is no longer included on the disk image.