### PR TITLE
NetLogo Download - fix code signature verification

### DIFF
--- a/NetLogo/NetLogo.download.recipe
+++ b/NetLogo/NetLogo.download.recipe
@@ -48,9 +48,9 @@ i.e.: `-k PRERELEASE=yes`</string>
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/NetLogo %version%/Behaviorsearch %version%.app</string>
+				<string>%pathname%/NetLogo %version%/BehaviorSearch %version%.app</string>
 				<key>requirement</key>
-				<string>identifier "org.nlogo.Behaviorsearch" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = E74ZKF37E6</string>
+				<string>identifier "org.nlogo.BehaviorSearch" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = E74ZKF37E6</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>


### PR DESCRIPTION
As of version 7.0.4 Behaviorsearch %version%.app has changed to BehaviorSearch %version%.app  This broke the code signature check.  This pull request fixes that issue.

Addresses : https://github.com/autopkg/vmiller-recipes/issues/71